### PR TITLE
Overhaul Travis & Codecov setup

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ coverage:
 
   status:
     project: no
-    patch: no
+    patch: yes
     changes: no
 
 comment:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: trusty
 language: c
 env:
   global:
@@ -16,7 +15,7 @@ addons:
 
 matrix:
   include:
-    - env: CFLAGS="-O2"
+    - env: CFLAGS="-O2" CC=clang CXX=clang++
       compiler: clang
     - env: CFLAGS="-O2"
       compiler: gcc
@@ -27,10 +26,10 @@ branches:
     - master
 
 before_script:
+  - export GAPROOT="$HOME/gap"
   - scripts/build_gap.sh
-  - scripts/build_pkg.sh
 script:
-  - scripts/run_tests.sh
+  - scripts/build_pkg.sh && scripts/run_tests.sh
 after_script:
   - bash scripts/gather-coverage.sh
   - bash <(curl -s https://codecov.io/bash)

--- a/scripts/build_gap.sh
+++ b/scripts/build_gap.sh
@@ -1,37 +1,31 @@
 #!/usr/bin/env bash
 set -ex
 
-# build GAP in a subdirectory
-git clone --depth=2 https://github.com/gap-system/gap.git $GAPROOT
+# clone GAP into a subdirectory
+git clone --depth=2 -b ${GAPBRANCH:-master} https://github.com/gap-system/gap.git $GAPROOT
 cd $GAPROOT
-./autogen.sh
-./configure
-make -j4 V=1
-make bootstrap-pkg-full
 
-GAPROOT="$(cd .. && pwd)"
-
-if [[ $ABI == 32 ]]
-then
-    CONFIGFLAGS="CFLAGS=-m32 LDFLAGS=-m32 LOPTS=-m32 CXXFLAGS=-m32"
+# for HPC-GAP, install ward, add suitable flags
+if [[ $HPCGAP = yes ]]; then
+  git clone https://github.com/gap-system/ward
+  cd ward
+  CFLAGS= LDFLAGS= ./build.sh
+  cd ..
+  GAP_CONFIGFLAGS="$GAP_CONFIGFLAGS --enable-hpcgap"
 fi
 
-# build some packages...
+# build GAP in a subdirectory
+./autogen.sh
+./configure $GAP_CONFIGFLAGS
+make -j4 V=1
+
+# download packages; instruct wget to retry several times if the
+# connection is refused, to work around intermittent failures
+make bootstrap-pkg-full WGET="wget -N --no-check-certificate --tries=5 --waitretry=5 --retry-connrefused"
+
+# build some packages (default is to build 'io' and 'profiling',
+# in order to generate coverage results)
 cd pkg
-
-cd io-*
-./autogen.sh
-./configure $CONFIGFLAGS
-make -j4 V=1
-cd ..
-
-cd profiling-*
-./autogen.sh
-# HACK to workaround problems when building with clang
-if [[ $CC = clang ]]
-then
-    export CXX=clang++
-fi
-./configure $CONFIGFLAGS
-make -j4 V=1
-cd ..
+for pkg in ${GAP_PKGS_TO_BUILD-io profiling}; do
+    ../bin/BuildPackages.sh --strict $pkg*
+done

--- a/scripts/build_pkg.sh
+++ b/scripts/build_pkg.sh
@@ -5,19 +5,20 @@ set -ex
 export CFLAGS="$CFLAGS -fprofile-arcs -ftest-coverage"
 export LDFLAGS="$LDFLAGS -fprofile-arcs"
 
-if [[ $ABI = 32 ]]
-then
+if [[ $ABI = 32 ]]; then
     export CFLAGS="$CFLAGS -m32"
     export LDFLAGS="$LDFLAGS -m32"
 fi
 
 # build this package
-# ./autogen.sh
-# ./configure --with-gaproot=$GAPROOT
-# make -j4 V=1
+if [[ -x autogen.sh ]]; then
+    ./autogen.sh
+    ./configure --with-gaproot=$GAPROOT
+    make -j4 V=1
+elif [[ -x configure ]]; then
+    ./configure $GAPROOT
+    make -j4
+fi
 
-# ... and link it into GAP pkg dir
-ls
-ls $GAPROOT
-ls $GAPROOT/pkg
-ln -s $PWD $GAPROOT/pkg/
+# trick to allow the package directory to be used as a GAP root dir
+ln -s . pkg

--- a/scripts/gather-coverage.sh
+++ b/scripts/gather-coverage.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 set -ex
 
-GAP="$GAPROOT/bin/gap.sh --quitonbreak -q"
+# If we don't care about code coverage, do nothing
+if [[ -n $NO_COVERAGE ]]; then
+    exit 0
+fi
+
+GAP="$GAPROOT/bin/gap.sh -l $PWD; --quitonbreak -q"
 
 # generate library coverage reports
 $GAP -a 500M -m 500M -q <<GAPInput
@@ -15,7 +20,7 @@ for f in DirectoryContents(d) do
     if f in [".", ".."] then continue; fi;
     Add(covs, Filename(d, f));
 od;
-Print("Merging coverage results\n");
+Print("Merging coverage results from ", covs, "\n");
 r := MergeLineByLineProfiles(covs);;
 Print("Outputting JSON\n");
 OutputJsonCoverage(r, "gap-coverage.json");;

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 set -ex
 
-GAP="$GAPROOT/bin/gap.sh --quitonbreak -q"
+GAP="$GAPROOT/bin/gap.sh -l $PWD; --quitonbreak"
 
-mkdir $COVDIR
-$GAP --cover $COVDIR/test.coverage tst/testall.g
+# unless explicitly turned off, we collect coverage data
+if [[ -z $NO_COVERAGE ]]; then
+    mkdir $COVDIR
+    GAP="$GAP --cover $COVDIR/test.coverage"
+fi
+
+$GAP tst/testall.g


### PR DESCRIPTION
For Codecov, actually enable status messages in pull requests (so far,
all were turned off, but for some reason codecov ignores this; still,
better to specify actual intent in the file).

For Travis, adapt scripts/build_pkg.sh to work with packages not using
autoconf, so that we can use the same script across many packages. Also
don't copy the tested package into GAP's pkg dir; instead, put it into
its own GAP root which we tell GAP to look at before its usual GAP root.

Modify scripts/gather-coverage.sh and scripts/run_tests.sh to use this
modified list of GAP root dirs

Simplify scripts/build_gap.sh significantly by using BuildPackages.sh.