### PR TITLE
Convert input to RootInt to integers first

### DIFF
--- a/lib/ecm.gi
+++ b/lib/ecm.gi
@@ -319,8 +319,8 @@ function ( arg )
   if ArgCorrect then
     n      := GetArg(1,"DoesNotExist",fail);
     Curves := GetArg(2,"ECMCurves",
-                     n -> Maximum(4,3 * RootInt(2^(LogInt(n,10) - 24),8)
-                                      + RootInt(2^(LogInt(n,10) - 50),4)));
+                     n -> Maximum(4,3 * RootInt(Int(2^(LogInt(n,10) - 24)),8)
+                                      + RootInt(Int(2^(LogInt(n,10) - 50)),4)));
     if   IsInt(Curves) 
     then NumberOfCurves := Curves; Curves := n -> NumberOfCurves; fi;
     if Curves(n) <= 0 then return [[],[n]]; fi;


### PR DESCRIPTION
Otherwise, for small enough inputs, we might pass a non-integral fraction
to RootInt. E.g.
```gap
  IsPrimeInt(100000000000000000000000000000000000000000000000151);
```
lead to a call to RootInt(1/32,4), which used to work due to a gap in
the input validation; but with a future optimized version of RootInt,
this GAP will be closed.