### PR TITLE
Tweak PackageInfo.g

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -50,14 +50,18 @@ Persons          := [
 Status           := "accepted",
 CommunicatedBy   := "Mike Atkinson (St. Andrews)",
 AcceptDate       := "07/1999",
-AbstractHTML     := Concatenation("This package provides routines for factoring integers, ",
-                                  "in particular:</p>\n<ul>\n  <li>Pollard's <em>p</em>-1</li>\n",
-                                  "  <li>Williams' <em>p</em>+1</li>\n  <li>Elliptic Curves ",
-                                  "Method (ECM)</li>\n  <li>Continued Fraction Algorithm ",
-                                  "(CFRAC)</li>\n  <li>Multiple Polynomial Quadratic Sieve ",
-                                  "(MPQS)</li>\n</ul>\n<p>It also provides access to Richard P. ",
-                                  "Brent's tables of factors of integers of the form ",
-                                  "<em>b</em>^<em>k</em> +/- 1."),
+AbstractHTML     := """
+This package provides routines for factoring integers, in particular:
+<ul>
+  <li>Pollard's <em>p</em>-1</li>
+  <li>Williams' <em>p</em>+1</li>
+  <li>Elliptic Curves Method (ECM)</li>
+  <li>Continued Fraction Algorithm (CFRAC)</li>
+  <li>Multiple Polynomial Quadratic Sieve (MPQS)</li>
+</ul>
+It also provides access to Richard P. Brent's tables of factors of integers of the form <em>b</em>^<em>k</em> +/- 1.
+""",
+
 PackageDoc       := rec(
                          BookName         := "FactInt",
                          ArchiveURLSubset := ["doc"],

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -74,9 +74,6 @@ Dependencies     := rec(
                          ExternalConditions     := [ ]
                        ),
 AvailabilityTest := ReturnTrue,
-BannerString     := Concatenation( "\nLoading FactInt ", ~.Version,
-                                   " (Routines for Integer Factorization)",
-                                   "\nby Stefan Kohl, stefan@gap-system.org\n\n" ),
 TestFile         := "tst/testall.g",
 Keywords         := [ "Integer factorization", "ECM", "Elliptic Curves Method",
                       "MPQS", "Multiple Polynomial Quadratic Sieve", "CFRAC",


### PR DESCRIPTION
The changes to `AbstractHTML` are also needed for smooth integration with GitHubPagesForGAP (without it, inserting the abstract into a markdown document breaks things, as it used to close a paragraph that it did not open, and opened a paragraph without closing it)